### PR TITLE
Upgrade to latest react testing library

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,7 +4,7 @@
     "import/no-unresolved": [
       "error",
       {
-        "ignore": ["jest-dom/extend-expect", "react-testing-library"]
+        "ignore": ["jest-dom/extend-expect", "@testing-library/react/cleanup-after-each"]
       }
     ]
   }

--- a/.eslintrc
+++ b/.eslintrc
@@ -4,7 +4,7 @@
     "import/no-unresolved": [
       "error",
       {
-        "ignore": ["jest-dom/extend-expect", "@testing-library/react/cleanup-after-each"]
+        "ignore": ["jest-dom/extend-expect", "@testing-library/react"]
       }
     ]
   }

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ should be installed as one of your project's `devDependencies`:
 npm install --save-dev react-beautiful-dnd-test-utils
 ```
 
-`jest`, `jest-dom` and `react-testing-library` must also be installed.
+`jest`, `jest-dom` and `@testing-library/react` must also be installed.
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "homepage": "https://github.com/colinrcummings/react-beautiful-dnd-test-utils#readme",
   "devDependencies": {
+    "@testing-library/react": "^8.0.1",
     "eslint": "^5.16.0",
     "eslint-config-colinrcummings": "^2.3.0",
     "prettier": "^1.17.0",
@@ -38,8 +39,8 @@
     "rollup": "^1.11.3"
   },
   "peerDependencies": {
+    "@testing-library/react": "^8.0.1",
     "jest": "^24.0.0",
-    "jest-dom": "^3.0.0",
-    "react-testing-library": "^7.0.0"
+    "jest-dom": "^3.0.0"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,5 +4,5 @@ export default {
     file: 'dist/index.cjs.js',
     format: 'cjs'
   },
-  external: ['jest', 'jest-dom/extend-expect', 'react-testing-library']
+  external: ['jest', 'jest-dom/extend-expect', '@testing-library/react']
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import 'jest-dom/extend-expect';
-import { fireEvent, waitForElement } from 'react-testing-library';
+import { fireEvent, waitForElement } from '@testing-library/react';
 
 /*
   window.getComputedStyle mock


### PR DESCRIPTION
The latest React Testing Library updated the package name to be namespaced under @testing-library.  

This PR updates the version requirements and adjusts the module path where it is referenced.